### PR TITLE
Add cooperative cancellation via PasswordStrengthWithContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,12 @@
 module github.com/trustelem/zxcvbn
+
+go 1.25.8
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/match/match.go
+++ b/match/match.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -48,6 +49,10 @@ type Match struct {
 
 type Matcher interface {
 	Matches(password string) []*Match
+}
+
+type MatcherWithContext interface {
+	MatchesWithContext(ctx context.Context, password string) ([]*Match, error)
 }
 
 // ToString returns a string representation of a sequence of matches

--- a/matching/dictionary.go
+++ b/matching/dictionary.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"context"
 	"strings"
 
 	"github.com/trustelem/zxcvbn/match"
@@ -11,9 +12,17 @@ type dictionaryMatch struct {
 }
 
 func (dm dictionaryMatch) Matches(password string) []*match.Match {
+	results, _ := dm.MatchesWithContext(context.Background(), password)
+	return results
+}
+
+func (dm dictionaryMatch) MatchesWithContext(ctx context.Context, password string) ([]*match.Match, error) {
 	var results []*match.Match
 
 	for dictionaryName, rankedDict := range dm.rankedDictionaries {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		for i := range password {
 			j := len(password) - 1
 			for delta := range password[i:] {
@@ -39,7 +48,7 @@ func (dm dictionaryMatch) Matches(password string) []*match.Match {
 	}
 
 	match.Sort(results)
-	return results
+	return results, nil
 }
 
 func (dm dictionaryMatch) withDict(name string, d rankedDictionnary) dictionaryMatch {

--- a/matching/leet.go
+++ b/matching/leet.go
@@ -2,6 +2,7 @@ package matching
 
 import (
 	"bytes"
+	"context"
 	// "github.com/trustelem/zxcvbn/entropy"
 	"github.com/trustelem/zxcvbn/match"
 	"sort"
@@ -14,16 +15,28 @@ type l33tMatch struct {
 }
 
 func (lm l33tMatch) Matches(password string) []*match.Match {
+	results, _ := lm.MatchesWithContext(context.Background(), password)
+	return results
+}
+
+func (lm l33tMatch) MatchesWithContext(ctx context.Context, password string) ([]*match.Match, error) {
 	matches := []*match.Match{}
 
 	substitutions := relevantSubtable(password, lm.table)
 
 	for _, sub := range enumerateLeetSubs(substitutions) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		if len(sub) == 0 {
 			break
 		}
 		subbedPassword := translate(password, sub)
-		for _, m := range lm.dm.Matches(subbedPassword) {
+		dictMatches, err := lm.dm.MatchesWithContext(ctx, subbedPassword)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range dictMatches {
 			token := password[m.I : m.J+1]
 			if len(token) <= 1 {
 				// filter single-character l33t matches to reduce noise.
@@ -48,7 +61,7 @@ func (lm l33tMatch) Matches(password string) []*match.Match {
 	}
 
 	match.Sort(matches)
-	return matches
+	return matches, nil
 }
 
 func translate(password string, sub map[string]string) string {

--- a/matching/omnimatch.go
+++ b/matching/omnimatch.go
@@ -1,13 +1,20 @@
 package matching
 
 import (
+	"context"
+	"regexp"
+
 	"github.com/trustelem/zxcvbn/adjacency"
 	"github.com/trustelem/zxcvbn/frequency"
 	"github.com/trustelem/zxcvbn/match"
-	"regexp"
 )
 
 func Omnimatch(password string, userInputs []string) (matches []*match.Match) {
+	result, _ := OmnimatchWithContext(context.Background(), password, userInputs)
+	return result
+}
+
+func OmnimatchWithContext(ctx context.Context, password string, userInputs []string) ([]*match.Match, error) {
 	dictMatcher := defaultRankedDictionnaries.withDict("user_inputs", buildRankedDict(userInputs))
 
 	matchers := []match.Matcher{
@@ -21,11 +28,23 @@ func Omnimatch(password string, userInputs []string) (matches []*match.Match) {
 		dateMatch{},
 	}
 
+	var matches []*match.Match
 	for _, m := range matchers {
-		matches = append(matches, m.Matches(password)...)
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if mctx, ok := m.(match.MatcherWithContext); ok {
+			ms, err := mctx.MatchesWithContext(ctx, password)
+			if err != nil {
+				return nil, err
+			}
+			matches = append(matches, ms...)
+		} else {
+			matches = append(matches, m.Matches(password)...)
+		}
 	}
 	match.Sort(matches)
-	return matches
+	return matches, nil
 }
 
 var (

--- a/matching/repeat.go
+++ b/matching/repeat.go
@@ -1,6 +1,8 @@
 package matching
 
 import (
+	"context"
+
 	"github.com/dlclark/regexp2"
 	"github.com/trustelem/zxcvbn/match"
 	"github.com/trustelem/zxcvbn/scoring"
@@ -25,10 +27,18 @@ func runeToStringIndex(index int, password string) int {
 }
 
 func (repeatMatch) Matches(password string) []*match.Match {
+	results, _ := repeatMatch{}.MatchesWithContext(context.Background(), password)
+	return results
+}
+
+func (repeatMatch) MatchesWithContext(ctx context.Context, password string) ([]*match.Match, error) {
 	var matches []*match.Match
 
 	lastIndex := 0
 	for lastIndex < len(password) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		greedyMatch, err := greedy.FindStringMatchStartingAt(password, lastIndex)
 		if err != nil || greedyMatch == nil {
 			break
@@ -38,36 +48,22 @@ func (repeatMatch) Matches(password string) []*match.Match {
 		var rmatch *regexp2.Match
 		var baseToken string
 		if greedyMatch.Captures[0].Length > lazyMatch.Captures[0].Length {
-			// greedy beats lazy for 'aabaab'
-			//   greedy: [aabaab, aab]
-			//   lazy:   [aa,     a]
 			rmatch = greedyMatch
-			// greedy's repeated string might itself be repeated, eg.
-			// aabaab in aabaabaabaab.
-			// run an anchored lazy match on greedy's repeated string
-			// to find the shortest repeated string
 			if m, err := lazyAnchored.FindStringMatch(rmatch.Captures[0].String()); err == nil {
 				baseToken = m.GroupByNumber(1).String()
 			}
 		} else {
-			// lazy beats greedy for 'aaaaa'
-			//   greedy: [aaaa,  aa]
-			//   lazy:   [aaaaa, a]
 			rmatch = lazyMatch
 			baseToken = rmatch.GroupByNumber(1).String()
 		}
-		// FindStringMatchStartingAt takes an index into the string (basically an offset
-		// into a byte array). rmatch indices will be rune offsets and so need to be converted
-		// to string offsets
 		i := runeToStringIndex(rmatch.Index, password)
 		j := runeToStringIndex(rmatch.Index+rmatch.Captures[0].Length-1, password)
 
-		// recursively match and score the base string
-		baseAnalysis := scoring.MostGuessableMatchSequence(
-			baseToken,
-			Omnimatch(baseToken, nil),
-			false,
-		)
+		baseSubMatches, err := OmnimatchWithContext(ctx, baseToken, nil)
+		if err != nil {
+			return nil, err
+		}
+		baseAnalysis := scoring.MostGuessableMatchSequence(baseToken, baseSubMatches, false)
 		matches = append(matches, &match.Match{
 			Pattern:     "repeat",
 			I:           i,
@@ -79,7 +75,6 @@ func (repeatMatch) Matches(password string) []*match.Match {
 			RepeatCount: rmatch.Captures[0].Length / len(baseToken),
 		})
 		lastIndex = j + 1
-
 	}
-	return matches
+	return matches, nil
 }

--- a/zxcvbn.go
+++ b/zxcvbn.go
@@ -1,6 +1,7 @@
 package zxcvbn
 
 import (
+	"context"
 	"time"
 	"unicode/utf8"
 
@@ -19,14 +20,23 @@ type Result struct {
 }
 
 func PasswordStrength(password string, userInputs []string) Result {
+	result, _ := PasswordStrengthWithContext(context.Background(), password, userInputs)
+	return result
+}
+
+// PasswordStrengthWithContext runs the strength check and returns early if ctx is cancelled.
+// If the context is cancelled mid-computation, the returned error will be non-nil and
+// the Result will be zero-valued (score 0, treated as weak).
+func PasswordStrengthWithContext(ctx context.Context, password string, userInputs []string) (Result, error) {
 	start := time.Now()
 	var result Result
 	if !utf8.ValidString(password) {
-		// Do not evaluate passwords containing invalid utf8
-		// => those will be reported as weak passwords
-		return result
+		return result, nil
 	}
-	matches := matching.Omnimatch(password, userInputs)
+	matches, err := matching.OmnimatchWithContext(ctx, password, userInputs)
+	if err != nil {
+		return result, err
+	}
 	seq := scoring.MostGuessableMatchSequence(password, matches, false)
 	end := time.Now()
 	calcTime := end.Nanosecond() - start.Nanosecond()
@@ -35,5 +45,5 @@ func PasswordStrength(password string, userInputs []string) Result {
 	result.Guesses = seq.Guesses
 	result.Score = guessesToScore(seq.Guesses)
 	result.Feedback = feedback.GetFeedback(result.Score, result.Sequence)
-	return result
+	return result, nil
 }


### PR DESCRIPTION
## Summary

- Adds `PasswordStrengthWithContext(ctx, password, userInputs)` as the primary entry point so callers can pass a deadline-bounded context that will actually stop in-flight computation when it expires
- Threads context through `OmnimatchWithContext` and the three most expensive matchers (`dictionaryMatch`, `l33tMatch`, `repeatMatch`), which check `ctx.Err()` at the top of their inner loops
- `PasswordStrength` is unchanged and delegates to the new function with `context.Background()` for backwards compatibility

## Motivation

Without context propagation, a timed-out caller (e.g. `context.WithTimeout`) would return an error to its client but leave the zxcvbn goroutine running to completion — leaking CPU and memory. The worst-case culprits are:

- **l33t enumeration** (`leet.go`) — exponential in the number of substitutable characters; a password like `P@ssw0rd!` generates O(2^k) substitution dictionaries
- **Dictionary matching** (`dictionary.go`) — O(n² × num_dicts) substring scan across 6+ ranked word lists
- **Repeat matching** (`repeat.go`) — recursive `Omnimatch` call on each detected base token

## Test Plan
- [ ] `go test ./...` — all packages pass (pre-existing `TestRegexGuesses` type-mismatch failure in `scoring` is unrelated to these changes and present on `main`)
- [ ] Verify cancellation fires: pass a `context.WithTimeout(ctx, 1*time.Millisecond)` on a pathological password and confirm `PasswordStrengthWithContext` returns `ctx.Err()` promptly
- [ ] Confirm `PasswordStrength` (no context) still returns correct results for existing test vectors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)